### PR TITLE
Fix random not-authorized errors

### DIFF
--- a/solver/llbsolver/ops/source.go
+++ b/solver/llbsolver/ops/source.go
@@ -39,7 +39,7 @@ func NewSourceOp(_ solver.Vertex, op *pb.Op_Source, platform *pb.Platform, sm *s
 	}, nil
 }
 
-func (s *sourceOp) instance(ctx context.Context) (source.SourceInstance, error) {
+func (s *sourceOp) instance(ctx context.Context, g session.Group) (source.SourceInstance, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.src != nil {
@@ -49,7 +49,7 @@ func (s *sourceOp) instance(ctx context.Context) (source.SourceInstance, error) 
 	if err != nil {
 		return nil, err
 	}
-	src, err := s.sm.Resolve(ctx, id, s.sessM)
+	src, err := s.sm.Resolve(ctx, id, s.sessM, g)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (s *sourceOp) instance(ctx context.Context) (source.SourceInstance, error) 
 }
 
 func (s *sourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*solver.CacheMap, bool, error) {
-	src, err := s.instance(ctx)
+	src, err := s.instance(ctx, g)
 	if err != nil {
 		return nil, false, err
 	}
@@ -80,7 +80,7 @@ func (s *sourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*s
 }
 
 func (s *sourceOp) Exec(ctx context.Context, g session.Group, _ []solver.Result) (outputs []solver.Result, err error) {
-	src, err := s.instance(ctx)
+	src, err := s.instance(ctx, g)
 	if err != nil {
 		return nil, err
 	}

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -98,7 +98,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 	return typed.dgst, typed.dt, nil
 }
 
-func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager) (source.SourceInstance, error) {
+func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, g session.Group) (source.SourceInstance, error) {
 	imageIdentifier, ok := id.(*source.ImageIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid image identifier %v", id)
@@ -124,7 +124,7 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		LeaseManager:  is.LeaseManager,
 		ResolverOpt: pull.ResolverOpt{
 			Hosts:      is.RegistryHosts,
-			Auth:       resolver.NewSessionAuthenticator(sm, nil),
+			Auth:       resolver.NewSessionAuthenticator(sm, g),
 			ImageStore: is.ImageStore,
 			Mode:       imageIdentifier.ResolveMode,
 			Ref:        imageIdentifier.Reference.String(),

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -166,7 +166,7 @@ func (gs *gitSourceHandler) shaToCacheKey(sha string) string {
 	return key
 }
 
-func (gs *gitSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager) (source.SourceInstance, error) {
+func (gs *gitSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, g session.Group) (source.SourceInstance, error) {
 	gitIdentifier, ok := id.(*source.GitIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid git identifier %v", id)

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -67,7 +67,7 @@ type httpSourceHandler struct {
 	sm       *session.Manager
 }
 
-func (hs *httpSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager) (source.SourceInstance, error) {
+func (hs *httpSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, g session.Group) (source.SourceInstance, error) {
 	httpIdentifier, ok := id.(*source.HttpIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid http identifier %v", id)

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -51,7 +51,7 @@ func (ls *localSource) ID() string {
 	return source.LocalScheme
 }
 
-func (ls *localSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager) (source.SourceInstance, error) {
+func (ls *localSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, g session.Group) (source.SourceInstance, error) {
 	localIdentifier, ok := id.(*source.LocalIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid local identifier %v", id)

--- a/source/manager.go
+++ b/source/manager.go
@@ -11,7 +11,7 @@ import (
 
 type Source interface {
 	ID() string
-	Resolve(ctx context.Context, id Identifier, sm *session.Manager) (SourceInstance, error)
+	Resolve(ctx context.Context, id Identifier, sm *session.Manager, g session.Group) (SourceInstance, error)
 }
 
 type SourceInstance interface {
@@ -36,7 +36,7 @@ func (sm *Manager) Register(src Source) {
 	sm.mu.Unlock()
 }
 
-func (sm *Manager) Resolve(ctx context.Context, id Identifier, sessM *session.Manager) (SourceInstance, error) {
+func (sm *Manager) Resolve(ctx context.Context, id Identifier, sessM *session.Manager, g session.Group) (SourceInstance, error) {
 	sm.mu.Lock()
 	src, ok := sm.sources[id.ID()]
 	sm.mu.Unlock()
@@ -45,5 +45,5 @@ func (sm *Manager) Resolve(ctx context.Context, id Identifier, sessM *session.Ma
 		return nil, errors.Errorf("no handler for %s", id.ID())
 	}
 
-	return src.Resolve(ctx, id, sessM)
+	return src.Resolve(ctx, id, sessM, g)
 }


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/191

Seems that this is caused by session group not being present in session authenticator sometimes. It's sporadic depending on whether the image config is resolved first (has session group) or image itself is resolved first (no session group).

This will be contributed upstream too.