### PR TITLE
Only mkdir when dir is specified

### DIFF
--- a/session/localhost/localhostprovider/localhostprovider.go
+++ b/session/localhost/localhostprovider/localhostprovider.go
@@ -55,9 +55,11 @@ func (lp *localhostProvider) Exec(stream localhost.Localhost_ExecServer) error {
 	lp.m.Lock()
 	defer lp.m.Unlock()
 
-	err = os.MkdirAll(workingDir, 0755)
-	if err != nil {
-		return errors.WithStack(err)
+	if workingDir != "" {
+		err = os.MkdirAll(workingDir, 0755)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, cmdStr, args...)


### PR DESCRIPTION
- when workdir is "" that means the current directory
- additionaly removes some left over debugging code that was
  issuing "ls -la"

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>