### PR TITLE
Add ctxutil to create context cancellations with stack traces

### DIFF
--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/buildkit/cache/remotecache"
 	"github.com/moby/buildkit/session"
 	sessioncontent "github.com/moby/buildkit/session/content"
+	"github.com/moby/buildkit/util/ctxutil"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -83,7 +84,7 @@ func getContentStore(ctx context.Context, sm *session.Manager, g session.Group, 
 	if sessionID == "" {
 		return nil, errors.New("local cache exporter/importer requires session")
 	}
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	timeoutCtx, cancel := ctxutil.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	caller, err := sm.Get(timeoutCtx, sessionID, false)

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/pkg/errors"
@@ -726,7 +727,7 @@ func testClientGatewayContainerPID1Tty(t *testing.T, sb integration.Sandbox) {
 	output := bytes.NewBuffer(nil)
 
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := ctxutil.WithTimeout(ctx, 10*time.Second)
 		defer timeout()
 
 		st := llb.Image("busybox:latest")
@@ -863,7 +864,7 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 	inputR, inputW := io.Pipe()
 	output := bytes.NewBuffer(nil)
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := ctxutil.WithTimeout(ctx, 10*time.Second)
 		defer timeout()
 		st := llb.Image("busybox:latest")
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/echoserver"
@@ -3377,7 +3378,7 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 
 // moby/buildkit#492
 func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := ctxutil.WithCancel(context.TODO())
 	defer cancel()
 
 	c, err := New(ctx, sb.Address())

--- a/client/solve.go
+++ b/client/solve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/entitlements"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -91,7 +92,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 	ref := identity.NewID()
 	eg, ctx := errgroup.WithContext(ctx)
 
-	statusContext, cancelStatus := context.WithCancel(context.Background())
+	statusContext, cancelStatus := ctxutil.WithCancel(context.Background())
 	defer cancelStatus()
 
 	if span := opentracing.SpanFromContext(ctx); span != nil {
@@ -179,7 +180,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 		opt.FrontendAttrs[k] = v
 	}
 
-	solveCtx, cancelSolve := context.WithCancel(ctx)
+	solveCtx, cancelSolve := ctxutil.WithCancel(ctx)
 	var res *SolveResponse
 	eg.Go(func() error {
 		ctx := solveCtx

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -1,13 +1,13 @@
 package common
 
 import (
-	"context"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/ctxutil"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -73,7 +73,7 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	}
 
 	timeout := time.Duration(c.GlobalInt("timeout"))
-	ctx, cancel := context.WithTimeout(ctx, timeout*time.Second)
+	ctx, cancel := ctxutil.WithTimeout(ctx, timeout*time.Second)
 	defer cancel()
 
 	return client.New(ctx, c.GlobalString("addr"), opts...)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/archutil"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/resolver"
@@ -184,7 +185,7 @@ func main() {
 		if os.Geteuid() > 0 {
 			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
 		}
-		ctx, cancel := context.WithCancel(appcontext.Context())
+		ctx, cancel := ctxutil.WithCancel(appcontext.Context())
 		defer cancel()
 
 		cfg, md, err := LoadFile(c.GlobalString("config"))
@@ -532,7 +533,7 @@ func unaryInterceptor(globalCtx context.Context) grpc.UnaryServerInterceptor {
 	withTrace := otgrpc.OpenTracingServerInterceptor(tracer, otgrpc.LogPayloads())
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := ctxutil.WithCancel(ctx)
 		defer cancel()
 
 		go func() {

--- a/control/control.go
+++ b/control/control.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/worker"
@@ -367,7 +368,7 @@ func (c *Controller) Session(stream controlapi.Control_SessionServer) error {
 	conn, closeCh, opts := grpchijack.Hijack(stream)
 	defer conn.Close()
 
-	ctx, cancel := context.WithCancel(stream.Context())
+	ctx, cancel := ctxutil.WithCancel(stream.Context())
 	go func() {
 		<-closeCh
 		cancel()

--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/buildkit/client/buildid"
 	"github.com/moby/buildkit/frontend/gateway"
 	gwapi "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -58,7 +59,7 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 		return nil, errors.New("no buildid found in context")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := ctxutil.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	go func() {

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/network"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -343,7 +344,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 
 	// resize in separate go loop so it does not potentially block
 	// the container cancel/exit status loop below.
-	resizeCtx, resizeCancel := context.WithCancel(ctx)
+	resizeCtx, resizeCancel := ctxutil.WithCancel(ctx)
 	defer resizeCancel()
 	go func() {
 		for {
@@ -370,7 +371,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 		case <-ctxDone:
 			ctxDone = nil
 			var killCtx context.Context
-			killCtx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+			killCtx, cancel = ctxutil.WithTimeout(context.Background(), 10*time.Second)
 			killCtxDone = killCtx.Done()
 			p.Kill(killCtx, syscall.SIGKILL)
 		case status := <-statusCh:

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/frontend/gateway/errdefs"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/network"
 	rootlessspecconv "github.com/moby/buildkit/util/rootless/specconv"
 	"github.com/moby/buildkit/util/stack"
@@ -290,7 +291,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	}
 
 	// runCtx/killCtx is used for extra check in case the kill command blocks
-	runCtx, cancelRun := context.WithCancel(context.Background())
+	runCtx, cancelRun := ctxutil.WithCancel(context.Background())
 	defer cancelRun()
 
 	ended := make(chan struct{})
@@ -298,7 +299,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		for {
 			select {
 			case <-ctx.Done():
-				killCtx, timeout := context.WithTimeout(context.Background(), 7*time.Second)
+				killCtx, timeout := ctxutil.WithTimeout(context.Background(), 7*time.Second)
 				if err := w.runc.Kill(killCtx, id, int(syscall.SIGKILL), nil); err != nil {
 					logrus.Errorf("failed to kill runc %s: %+v", id, err)
 					select {

--- a/executor/runcexecutor/executor_linux.go
+++ b/executor/runcexecutor/executor_linux.go
@@ -11,6 +11,7 @@ import (
 	runc "github.com/containerd/go-runc"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -45,7 +46,7 @@ func (w *runcExecutor) exec(ctx context.Context, id, bundle string, specsProcess
 type runcCall func(ctx context.Context, started chan<- int, io runc.IO) error
 
 func (w *runcExecutor) callWithIO(ctx context.Context, id, bundle string, process executor.ProcessInfo, call runcCall) error {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	if !process.Meta.Tty {
@@ -108,7 +109,7 @@ func (w *runcExecutor) callWithIO(ctx context.Context, id, bundle string, proces
 	started := make(chan int, 1)
 
 	eg.Go(func() error {
-		startedCtx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		startedCtx, timeout := ctxutil.WithTimeout(ctx, 10*time.Second)
 		defer timeout()
 		var runcProcess *os.Process
 		select {

--- a/exporter/earthlyoutputs/export.go
+++ b/exporter/earthlyoutputs/export.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress"
@@ -304,7 +305,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 		descs[imgName] = desc
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeoutCtx, cancel := ctxutil.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -48,7 +49,7 @@ func (e *localExporterInstance) Name() string {
 
 func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source, sessionID string) (map[string]string, error) {
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeoutCtx, cancel := ctxutil.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress"
@@ -166,7 +167,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 		return nil, errors.Errorf("invalid variant %q", e.opt.Variant)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeoutCtx, cancel := ctxutil.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -132,7 +133,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source,
 		fs = d.FS
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeoutCtx, cancel := ctxutil.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/moby/buildkit/session/upload/uploadprovider"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -2711,7 +2712,7 @@ COPY . .
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := ctxutil.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	c, err := client.New(ctx, sb.Address())

--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/mounts"
 	"github.com/moby/buildkit/solver/pb"
 	opspb "github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/stack"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/worker"
@@ -41,7 +42,7 @@ type Mount struct {
 }
 
 func NewContainer(ctx context.Context, w worker.Worker, sm *session.Manager, g session.Group, req NewContainerRequest) (client.Container, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	platform := opspb.Platform{
 		OS:           runtime.GOOS,

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -34,6 +34,7 @@ import (
 	llberrdefs "github.com/moby/buildkit/solver/llbsolver/errdefs"
 	opspb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/buildkit/util/tracing"
@@ -357,7 +358,7 @@ func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridg
 }
 
 func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	lbf := newBridgeForwarder(ctx, llbBridge, workers, inputs, sid, sm)
 	maxMsgSize := 67108864 // 64MB
 	server := grpc.NewServer(
@@ -1132,7 +1133,7 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 					return stack.Enable(status.Errorf(codes.NotFound, "container %q previously released or not created", id))
 				}
 
-				initCtx, initCancel := context.WithCancel(context.Background())
+				initCtx, initCancel := ctxutil.WithCancel(context.Background())
 				defer initCancel()
 
 				pio := newProcessIO(pid, init.Fds)

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	opspb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ type GrpcClient interface {
 }
 
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
-	pingCtx, pingCancel := context.WithTimeout(ctx, 15*time.Second)
+	pingCtx, pingCancel := ctxutil.WithTimeout(ctx, 15*time.Second)
 	defer pingCancel()
 	resp, err := c.Ping(pingCtx, &pb.PingRequest{})
 	if err != nil {
@@ -544,7 +545,7 @@ type messageForwarder struct {
 }
 
 func newMessageForwarder(ctx context.Context, client pb.LLBBridgeClient) *messageForwarder {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	return &messageForwarder{
 		client: client,
@@ -1017,7 +1018,7 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	_ = cancel
 	// go monitorHealth(ctx, cc, cancel)
 

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -201,7 +202,7 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 
 	opts[keyDirName] = []string{opt.Name}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	client := NewFileSyncClient(c.Conn())

--- a/session/group.go
+++ b/session/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 )
 
@@ -72,7 +73,7 @@ func (sm *Manager) Any(ctx context.Context, g Group, f func(context.Context, str
 			return errors.Errorf("no active sessions")
 		}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		timeoutCtx, cancel := ctxutil.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		c, err := sm.Get(timeoutCtx, id, false)
 		if err != nil {

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/defaults"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -72,7 +73,7 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	go monitorHealth(ctx, cc, cancel)
 
 	return ctx, cc, nil
@@ -91,7 +92,7 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func()) 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			ctx, cancel := ctxutil.WithTimeout(ctx, 10*time.Second)
 			_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 			cancel()
 			if err != nil {

--- a/session/manager.go
+++ b/session/manager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -99,7 +100,7 @@ func (sm *Manager) HandleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 // caller needs to take lock, this function will release it
 func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[string][]string) error {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	opts = canonicalHeaders(opts)
@@ -156,7 +157,7 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 		id = p[1]
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	go func() {

--- a/session/session.go
+++ b/session/session.go
@@ -8,6 +8,7 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -99,7 +100,7 @@ func (s *Session) ID() string {
 
 // Run activates the session
 func (s *Session) Run(ctx context.Context, dialer Dialer) error {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	s.cancelCtx = cancel
 	s.done = make(chan struct{})
 

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 )
 
@@ -70,7 +71,7 @@ type Status struct {
 func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func()) {
 	p := New(Request{})
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := ctxutil.WithCancel(context.TODO())
 
 	p.OnReceiveCompletion = func() {
 		if req := p.Sender.Request(); req.Canceled {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/tracing"
@@ -451,7 +452,7 @@ func (jl *Solver) NewJob(id string) (*Job, error) {
 }
 
 func (jl *Solver) Get(id string) (*Job, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := ctxutil.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	go func() {

--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/moby/buildkit/session/sshforward"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/locker"
 	"github.com/pkg/errors"
@@ -202,7 +203,7 @@ type sshMountInstance struct {
 }
 
 func (sm *sshMountInstance) Mount() ([]mount.Mount, func() error, error) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := ctxutil.WithCancel(context.TODO())
 
 	uid := int(sm.sm.mount.SSHOpt.Uid)
 	gid := int(sm.sm.mount.SSHOpt.Gid)

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/buildkit/solver/internal/pipe"
 	"github.com/moby/buildkit/util/cond"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -231,7 +232,7 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	}
 	s.mu.Unlock()
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	go func() {

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/ctxutil"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -489,7 +490,7 @@ func TestSingleCancelCache(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 
 	g0 := Edge{
 		Vertex: vtx(vtxOpt{
@@ -532,7 +533,7 @@ func TestSingleCancelExec(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 
 	g1 := Edge{
 		Vertex: vtx(vtxOpt{
@@ -582,7 +583,7 @@ func TestSingleCancelParallel(t *testing.T) {
 			}
 		}()
 
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := ctxutil.WithCancel(ctx)
 		defer cancel()
 
 		g := Edge{

--- a/util/appcontext/appcontext.go
+++ b/util/appcontext/appcontext.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"sync"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,7 +23,7 @@ func Context() context.Context {
 		const exitLimit = 3
 		retries := 0
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := ctxutil.WithCancel(context.Background())
 		appContextCache = ctx
 
 		go func() {

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -65,12 +65,12 @@ func (c ctxWithStackTrace) Done() <-chan struct{} {
 func (c ctxWithStackTrace) Err() error {
 	select {
 	case <-c.ctx.Done():
-		// @# ret := c.ctx.Err()
+		ret := c.ctx.Err()
 		<-c.doneCh
 		if c.err != nil {
 			fmt.Printf("@#@#@# Err: %s Stack: %s\n", c.err.Error(), getStackTrace(c.err))
 		}
-		return c.err
+		return ret
 	default:
 	}
 	return nil

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -1,0 +1,62 @@
+package ctxutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// WithCancel is equivalent to context.WithCancel, but it also adds in a stack trace
+// of where the WithCancel has been created.
+func WithCancel(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	return newCtxWithStackTrace(ctx), cancel
+}
+
+// WithTimeout is equivalent to context.WithTimeout, but it also adds in a stack trace
+// of where the WithTimeout has been created.
+func WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	return newCtxWithStackTrace(ctx), cancel
+}
+
+type ctxWithStackTrace struct {
+	ctx                 context.Context
+	canceledErr         error
+	deadlineExceededErr error
+}
+
+func newCtxWithStackTrace(parent context.Context) context.Context {
+	c := ctxWithStackTrace{
+		ctx:                 parent,
+		canceledErr:         errors.WithStack(context.Canceled),
+		deadlineExceededErr: errors.WithStack(context.DeadlineExceeded),
+	}
+	return c
+}
+
+func (c ctxWithStackTrace) Deadline() (time.Time, bool) {
+	return c.ctx.Deadline()
+}
+
+func (c ctxWithStackTrace) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+func (c ctxWithStackTrace) Err() error {
+	ctxErr := c.ctx.Err()
+	if errors.Is(ctxErr, context.Canceled) {
+		return c.canceledErr
+	}
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return c.deadlineExceededErr
+	}
+	// this would not include a stack trace (or it would include the stack trace of
+	// the context that was done).
+	return ctxErr
+}
+
+func (c ctxWithStackTrace) Value(key interface{}) interface{} {
+	return c.ctx.Value(key)
+}

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -22,17 +22,34 @@ func WithTimeout(parent context.Context, timeout time.Duration) (context.Context
 }
 
 type ctxWithStackTrace struct {
-	ctx                 context.Context
-	canceledErr         error
-	deadlineExceededErr error
+	ctx context.Context
+
+	doneCh chan struct{}
+	err    error
 }
 
 func newCtxWithStackTrace(parent context.Context) context.Context {
 	c := ctxWithStackTrace{
-		ctx:                 parent,
-		canceledErr:         errors.WithStack(context.Canceled),
-		deadlineExceededErr: errors.WithStack(context.DeadlineExceeded),
+		ctx:    parent,
+		doneCh: make(chan struct{}),
 	}
+	canceledErr := errors.WithStack(context.Canceled)
+	deadlineExceededErr := errors.WithStack(context.DeadlineExceeded)
+	go func() {
+		<-c.doneCh
+		ctxErr := c.ctx.Err()
+		switch ctxErr {
+		case context.Canceled:
+			c.err = canceledErr
+		case context.DeadlineExceeded:
+			c.err = deadlineExceededErr
+		default:
+			// this would not include a stack trace (or it would include the stack trace of
+			// the context that was done).
+			c.err = ctxErr
+		}
+		close(c.doneCh)
+	}()
 	return c
 }
 
@@ -41,20 +58,16 @@ func (c ctxWithStackTrace) Deadline() (time.Time, bool) {
 }
 
 func (c ctxWithStackTrace) Done() <-chan struct{} {
-	return c.ctx.Done()
+	return c.doneCh
 }
 
 func (c ctxWithStackTrace) Err() error {
-	ctxErr := c.ctx.Err()
-	if errors.Is(ctxErr, context.Canceled) {
-		return c.canceledErr
+	select {
+	case <-c.doneCh:
+		return c.err
+	default:
 	}
-	if errors.Is(ctxErr, context.DeadlineExceeded) {
-		return c.deadlineExceededErr
-	}
-	// this would not include a stack trace (or it would include the stack trace of
-	// the context that was done).
-	return ctxErr
+	return nil
 }
 
 func (c ctxWithStackTrace) Value(key interface{}) interface{} {

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -67,7 +67,9 @@ func (c ctxWithStackTrace) Err() error {
 	case <-c.ctx.Done():
 		// @# ret := c.ctx.Err()
 		<-c.doneCh
-		fmt.Printf("@#@#@# Err: %s Stack: %s\n", c.err.Error(), getStackTrace(c.err))
+		if c.err != nil {
+			fmt.Printf("@#@#@# Err: %s Stack: %s\n", c.err.Error(), getStackTrace(c.err))
+		}
 		return c.err
 	default:
 	}

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -2,6 +2,7 @@ package ctxutil
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,8 +31,8 @@ type ctxWithStackTrace struct {
 
 func newCtxWithStackTrace(parent context.Context) context.Context {
 	c := ctxWithStackTrace{
-		ctx:    parent,
 		doneCh: make(chan struct{}),
+		ctx:    parent,
 	}
 	canceledErr := errors.WithStack(context.Canceled)
 	deadlineExceededErr := errors.WithStack(context.DeadlineExceeded)
@@ -58,12 +59,15 @@ func (c ctxWithStackTrace) Deadline() (time.Time, bool) {
 }
 
 func (c ctxWithStackTrace) Done() <-chan struct{} {
-	return c.doneCh
+	return c.ctx.Done()
 }
 
 func (c ctxWithStackTrace) Err() error {
 	select {
-	case <-c.doneCh:
+	case <-c.ctx.Done():
+		// @# ret := c.ctx.Err()
+		<-c.doneCh
+		fmt.Printf("@#@#@# Err: %s Stack: %s\n", c.err.Error(), getStackTrace(c.err))
 		return c.err
 	default:
 	}
@@ -72,4 +76,22 @@ func (c ctxWithStackTrace) Err() error {
 
 func (c ctxWithStackTrace) Value(key interface{}) interface{} {
 	return c.ctx.Value(key)
+}
+
+func getStackTrace(err error) string {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	errChain := []error{}
+	for it := err; it != nil; it = errors.Unwrap(it) {
+		errChain = append(errChain, it)
+	}
+	for index := len(errChain) - 1; index > 0; index-- {
+		it := errChain[index]
+		errWithStack, ok := it.(stackTracer)
+		if ok {
+			return fmt.Sprintf("%+v", errWithStack.StackTrace())
+		}
+	}
+	return ""
 }

--- a/util/ctxutil/ctxutil.go
+++ b/util/ctxutil/ctxutil.go
@@ -36,7 +36,7 @@ func newCtxWithStackTrace(parent context.Context) context.Context {
 	canceledErr := errors.WithStack(context.Canceled)
 	deadlineExceededErr := errors.WithStack(context.DeadlineExceeded)
 	go func() {
-		<-c.doneCh
+		<-c.ctx.Done()
 		ctxErr := c.ctx.Err()
 		switch ctxErr {
 		case context.Canceled:

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/pkg/errors"
 )
@@ -116,7 +117,7 @@ func newCall(fn func(ctx context.Context) (interface{}, error)) *call {
 
 func (c *call) run() {
 	defer c.closeProgressWriter()
-	ctx, cancel := context.WithCancel(c.ctx)
+	ctx, cancel := ctxutil.WithCancel(c.ctx)
 	defer cancel()
 	v, err := c.fn(ctx)
 	c.mu.Lock()
@@ -146,7 +147,7 @@ func (c *call) wait(ctx context.Context) (v interface{}, err error) {
 		c.progressState.add(pw)
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	defer cancel()
 
 	c.ctxs = append(c.ctxs, ctx)

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestCancelOne(t *testing.T) {
 	var r1, r2 string
 	var counter int64
 	f := testFunc(100*time.Millisecond, "bar", &counter)
-	ctx2, cancel := context.WithCancel(ctx)
+	ctx2, cancel := ctxutil.WithCancel(ctx)
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
 		assert.Error(t, err)
@@ -87,7 +88,7 @@ func TestCancelRace(t *testing.T) {
 	// t.Parallel() // disabled for better timing consistency. works with parallel as well
 
 	g := &Group{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := ctxutil.WithCancel(context.Background())
 
 	kick := make(chan struct{})
 	wait := make(chan struct{})
@@ -145,8 +146,8 @@ func TestCancelBoth(t *testing.T) {
 	var r1, r2 string
 	var counter int64
 	f := testFunc(200*time.Millisecond, "bar", &counter)
-	ctx2, cancel2 := context.WithCancel(ctx)
-	ctx3, cancel3 := context.WithCancel(ctx)
+	ctx2, cancel2 := ctxutil.WithCancel(ctx)
+	ctx3, cancel3 := ctxutil.WithCancel(ctx)
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
 		assert.Error(t, err)

--- a/util/progress/progress.go
+++ b/util/progress/progress.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 )
 
@@ -161,7 +162,7 @@ func (pr *progressReader) append(pw *progressWriter) {
 }
 
 func pipe() (*progressReader, *progressWriter, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := ctxutil.WithCancel(context.Background())
 	pr := &progressReader{
 		ctx:     ctx,
 		writers: make(map[*progressWriter]struct{}),

--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/util/progress"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func (p *ProviderWithProgress) ReaderAt(ctx context.Context, desc ocispec.Descri
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	go trackProgress(ctx, desc, p.Manager, doneCh)
 	return readerAtWithCancel{ReaderAt: ra, cancel: cancel, doneCh: doneCh}, nil
@@ -63,7 +64,7 @@ func (f *FetcherWithProgress) Fetch(ctx context.Context, desc ocispec.Descriptor
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	go trackProgress(ctx, desc, f.Manager, doneCh)
 	return readerWithCancel{ReadCloser: rc, cancel: cancel, doneCh: doneCh}, nil

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -25,11 +25,16 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 					return nil, err
 				default:
 					if !retryError(err) {
+						if logger != nil {
+							st := getStackTrace(err)
+							logger([]byte(fmt.Sprintf("error: %v\nstack trace: %s\n", err.Error(), st)))
+						}
 						return nil, err
 					}
 				}
 				if logger != nil {
-					logger([]byte(fmt.Sprintf("error: %v\n", err.Error())))
+					st := getStackTrace(err)
+					logger([]byte(fmt.Sprintf("error: %v\nstack trace: %s\n", err.Error(), st)))
 				}
 			} else {
 				return descs, nil
@@ -48,11 +53,14 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 }
 
 func retryError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
 		return true
 	}
 	// catches TLS timeout or other network-related temporary errors.
-	if ne, ok := errors.Cause(err).(net.Error); ok && (ne.Timeout() || ne.Temporary()) {
+	if ne, ok := errors.Cause(err).(net.Error); ok && ne.Temporary() {
 		return true
 	}
 	// https://github.com/containerd/containerd/pull/4724
@@ -66,4 +74,22 @@ func retryError(err error) bool {
 	}
 
 	return false
+}
+
+func getStackTrace(err error) string {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	errChain := []error{}
+	for it := err; it != nil; it = errors.Unwrap(it) {
+		errChain = append(errChain, it)
+	}
+	for index := len(errChain) - 1; index > 0; index-- {
+		it := errChain[index]
+		errWithStack, ok := it.(stackTracer)
+		if ok {
+			return fmt.Sprintf("%+v", errWithStack.StackTrace())
+		}
+	}
+	return ""
 }

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/docker/testutil/daemon"
+	"github.com/moby/buildkit/util/ctxutil"
 )
 
 const dockerdBinary = "dockerd"
@@ -86,7 +87,7 @@ func (c dockerd) New(cfg *BackendConfig) (b Backend, cl func() error, err error)
 		return nil, nil, fmt.Errorf("dockerd did not start up: %q, %s", err, formatLogs(logs))
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := ctxutil.WithCancel(context.Background())
 	deferF.append(func() error { cancel(); return nil })
 
 	dockerAPI, err := cmd.NewClient()

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/pkg/errors"
 )
 
@@ -68,7 +69,7 @@ http:
 	}
 	deferF.append(stop)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := ctxutil.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	url, err = detectPort(ctx, rc)
 	if err != nil {

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/source"
+	"github.com/moby/buildkit/util/ctxutil"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func NewCtx(s string) context.Context {
 
 func TestWorkerExec(t *testing.T, w *base.Worker) {
 	ctx := NewCtx("buildkit-test")
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := ctxutil.WithCancel(ctx)
 	sm, err := session.NewManager()
 	require.NoError(t, err)
 
@@ -50,7 +51,7 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 	id := identity.NewID()
 
 	// verify pid1 exits when stdin sees EOF
-	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 5*time.Second)
+	ctxTimeout, cancelTimeout := ctxutil.WithTimeout(ctx, 5*time.Second)
 	started := make(chan struct{})
 	pipeR, pipeW := io.Pipe()
 	go func() {


### PR DESCRIPTION
This adds stacks to `context.Err()` for where the `WithTimeout` or the `WithCancel` were created. This will hopefully help us find where the cancellations come from.

This is not 100% according to spec as the spec is says `.Err()` should only return `context.Canceled` or `context.DeadlineExceeded` (whereas we return those but wrapped in something else):

```
    // If Done is not yet closed, Err returns nil.
    // If Done is closed, Err returns a non-nil error explaining why:
    // Canceled if the context was canceled
    // or DeadlineExceeded if the context's deadline passed.
    // After Err returns a non-nil error, successive calls to Err return the same error.
    Err() error
```

Not sure how I feel about this. FWIW, I don't see any buildkit code that relies on that assumption (everything checks using `errors.Is`).