### PR TITLE
Increase initial window size for grpc communication

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -32,6 +32,8 @@ type ClientOpt interface{}
 // New returns a new buildkit client. Address can be empty for the system-default address.
 func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
+		grpc.WithInitialWindowSize(65535 * 32),
+		grpc.WithInitialConnWindowSize(65535 * 16),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 	}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -214,6 +214,8 @@ func main() {
 		opts := []grpc.ServerOption{
 			grpc.UnaryInterceptor(unary), grpc.StreamInterceptor(stream),
 			grpc.MaxRecvMsgSize(maxMsgSize), grpc.MaxSendMsgSize(maxMsgSize),
+			grpc.InitialWindowSize(65535 * 32),
+			grpc.InitialConnWindowSize(65535 * 16),
 		}
 		server := grpc.NewServer(opts...)
 

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -319,6 +319,8 @@ func snapshotterFactory(commonRoot string, cfg config.OCIConfig, hosts docker.Re
 				grpc.WithInsecure(),
 				grpc.WithConnectParams(connParams),
 				grpc.WithContextDialer(dialer.ContextDialer),
+				grpc.WithInitialWindowSize(65535 * 32),
+				grpc.WithInitialConnWindowSize(65535 * 16),
 				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 				grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 			}

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -364,6 +364,8 @@ func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLB
 		grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
 		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
 		grpc.MaxRecvMsgSize(maxMsgSize), grpc.MaxSendMsgSize(maxMsgSize),
+		grpc.InitialWindowSize(65535*32),
+		grpc.InitialConnWindowSize(65535*16),
 	)
 	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 	pb.RegisterLLBBridgeServer(server, lbf)

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1011,6 +1011,8 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
+		grpc.WithInitialWindowSize(65535*32),
+		grpc.WithInitialConnWindowSize(65535*16),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)))
 	if err != nil {

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -42,6 +42,8 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 	dialOpts := []grpc.DialOption{
 		dialer,
 		grpc.WithInsecure(),
+		grpc.WithInitialWindowSize(65535 * 32),
+		grpc.WithInitialConnWindowSize(65535 * 16),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 	}

--- a/session/grpchijack/dial.go
+++ b/session/grpchijack/dial.go
@@ -41,7 +41,7 @@ type stream interface {
 
 func streamToConn(stream stream) (net.Conn, <-chan struct{}) {
 	closeCh := make(chan struct{})
-	c := &conn{stream: stream, buf: make([]byte, 32*1<<10), closeCh: closeCh}
+	c := &conn{stream: stream, buf: make([]byte, 32*1<<6), closeCh: closeCh}
 	return c, closeCh
 }
 

--- a/session/grpchijack/dial.go
+++ b/session/grpchijack/dial.go
@@ -41,7 +41,7 @@ type stream interface {
 
 func streamToConn(stream stream) (net.Conn, <-chan struct{}) {
 	closeCh := make(chan struct{})
-	c := &conn{stream: stream, buf: make([]byte, 32*1<<6), closeCh: closeCh}
+	c := &conn{stream: stream, buf: make([]byte, 32*1<<10), closeCh: closeCh}
 	return c, closeCh
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -53,6 +53,8 @@ func NewSession(ctx context.Context, name, sharedKey string) (*Session, error) {
 	maxMsgSize := 67108864 // 64MB
 	serverOpts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(maxMsgSize), grpc.MaxSendMsgSize(maxMsgSize),
+		grpc.InitialWindowSize(65535 * 32),
+		grpc.InitialConnWindowSize(65535 * 16),
 	}
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		tracer := span.Tracer()


### PR DESCRIPTION
This should eliminate errors like these `received 68586-bytes data exceeding the limit 65535 bytes`.

Re https://github.com/earthly/earthly/issues/1016