### PR TITLE
Create locking mechanism to allow for sequential execs

### DIFF
--- a/session/localhost/localhost.go
+++ b/session/localhost/localhost.go
@@ -26,6 +26,13 @@ const CopyFileMagicStr = "39a51ba7-d8c6-43ac-b3aa-f987b2db1ced"
 // it's used as "SendFileMagicStr src dest"
 const SendFileMagicStr = "98325231-d2e6-931c-b12a-84273bca21db"
 
+// RunOnLocalHostLockMagicStr is a magic argument that indicates the next argument should be used as a lock name to require
+// if it is aleady locked, it will continue
+const RunOnLocalHostLockMagicStr = "51e6f7d5-b1f9-40c6-aa8a-dac4eb1d8cbd"
+
+// RunOnLocalHostUnlockMagicStr is a magic argument that indicates the next argument should be used as a lock name to unlock
+const RunOnLocalHostUnlockMagicStr = "3e9851fe-d820-453b-a05e-187af9ab085c"
+
 // Mountable is from buildkit/snapshot; however the snapshot package wont build on darwin
 // so we must pull this in here to avoid pulling in linux-specific packages.
 type Mountable interface {

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/errdefs"
 	"github.com/moby/buildkit/solver/llbsolver/mounts"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/locallylock"
 	"github.com/moby/buildkit/util/progress/logs"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/worker"
@@ -35,6 +36,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
+
+var localLock *locallylock.Lock
+
+func init() {
+	localLock = locallylock.New()
+}
 
 const execCacheType = "buildkit.exec.v0"
 
@@ -519,6 +526,9 @@ func (e *execOp) sendLocally(ctx context.Context, root executor.Mount, mounts []
 	})
 }
 
+var errMagicArgUnderflow = fmt.Errorf("magic arg underflow")
+var errUnexpectedArgs = fmt.Errorf("unexpected args")
+
 func (e *execOp) execLocally(ctx context.Context, root executor.Mount, g session.Group, meta executor.Meta, stdout, stderr io.WriteCloser) error {
 	if len(meta.Args) == 0 || meta.Args[0] != localhost.RunOnLocalHostMagicStr {
 		panic("first arg should be RunOnLocalHostMagicStr; this should not happen")
@@ -526,7 +536,46 @@ func (e *execOp) execLocally(ctx context.Context, root executor.Mount, g session
 	args := meta.Args[1:] // remove magic uuid from command prefix; the rest that follows is the actual command to run
 	cwd := meta.Cwd
 
+	var lockName string
+	var doUnlock bool
+
+outer:
+	for len(args) > 0 {
+		switch args[0] {
+		case localhost.RunOnLocalHostLockMagicStr:
+			if len(args) < 2 {
+				return errMagicArgUnderflow
+			}
+			lockName = args[1]
+			args = args[2:]
+		case localhost.RunOnLocalHostUnlockMagicStr:
+			if len(args) < 2 {
+				return errMagicArgUnderflow
+			}
+			lockName = args[1]
+			doUnlock = true
+			args = args[2:]
+		default:
+			break outer
+		}
+	}
+
+	if doUnlock && len(args) > 0 {
+		return errUnexpectedArgs
+	}
+
 	return e.sm.Any(ctx, g, func(ctx context.Context, _ string, caller session.Caller) error {
+		if lockName != "" {
+			// lock must be called prior to unlocking to prevent unlocking the incorrect lock
+			logrus.Debugf("localLock lock %q", lockName)
+			localLock.Lock(ctx, lockName)
+			if doUnlock {
+				logrus.Debugf("localLock unlock %q", lockName)
+				localLock.Unlock()
+				return nil
+			}
+		}
+
 		logrus.Debugf("localexec dir=%s; args=%v", cwd, args)
 		err := localhost.LocalhostExec(ctx, caller, args, cwd, stdout, stderr)
 		if err != nil {

--- a/util/locallylock/lock.go
+++ b/util/locallylock/lock.go
@@ -1,0 +1,52 @@
+package locallylock
+
+import (
+	"context"
+	"sync"
+)
+
+type Lock struct {
+	m       *sync.Mutex
+	c       *sync.Cond
+	current string
+	ctx     context.Context
+}
+
+func New() *Lock {
+	m := sync.Mutex{}
+	c := sync.NewCond(&m)
+
+	return &Lock{
+		m: &m,
+		c: c,
+	}
+}
+
+func (l *Lock) Lock(ctx context.Context, name string) {
+	l.m.Lock()
+	for {
+		if l.ctx != nil {
+			select {
+			case <-l.ctx.Done():
+				// unlock locks from closed connections
+				l.current = ""
+			default:
+			}
+		}
+		if l.current == "" || l.current == name {
+			l.current = name
+			l.ctx = ctx
+			l.m.Unlock()
+			return
+		}
+		l.c.Wait()
+	}
+}
+
+func (l *Lock) Unlock() {
+	l.m.Lock()
+	l.current = ""
+	l.ctx = nil
+	l.m.Unlock()
+	l.c.Broadcast()
+}

--- a/util/locallylock/lock_test.go
+++ b/util/locallylock/lock_test.go
@@ -1,0 +1,55 @@
+package locallylock
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestLock(t *testing.T) {
+	l := New()
+	wg := sync.WaitGroup{}
+	seen := map[string]int{}
+
+	looper := func(name string) {
+		defer wg.Done()
+		ctx := context.Background()
+		l.Lock(ctx, name)
+		before := len(seen)
+		for i := 0; i < 100; i++ {
+			l.Lock(ctx, name)
+			seen[name]++
+		}
+		after := len(seen)
+		l.Unlock()
+		if (before + 1) != after {
+			t.Error("out of order loops")
+		}
+	}
+
+	wg.Add(3)
+	go looper("a")
+	go looper("b")
+	go looper("c")
+
+	wg.Wait()
+	if len(seen) != 3 {
+		t.Error("not all 3 loopers ran")
+	}
+}
+
+func TestCanceledLock(t *testing.T) {
+	l := New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l.Lock(ctx, "a")
+
+	cancel()
+
+	ctx2 := context.Background()
+	l.Lock(ctx2, "b")
+	l.Unlock()
+
+	l.Lock(ctx2, "c")
+}


### PR DESCRIPTION
Create two magic-string args for specifying lock and unlock ops.
Locks are referenced with a string name, additional locks on a
previously locked lock of the same name are ignored.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>