### PR TITLE
Corey/configurable-logging-timeout

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	resolverconfig "github.com/moby/buildkit/util/resolver/config"
 )
 
@@ -24,6 +26,8 @@ type Config struct {
 	Registries map[string]resolverconfig.RegistryConfig `toml:"registry"`
 
 	DNS *DNSConfig `toml:"dns"`
+
+	Health HealthConfig `toml:"health"`
 }
 
 type GRPCConfig struct {
@@ -35,6 +39,12 @@ type GRPCConfig struct {
 	TLS TLSConfig `toml:"tls"`
 	// MaxRecvMsgSize int    `toml:"max_recv_message_size"`
 	// MaxSendMsgSize int    `toml:"max_send_message_size"`
+}
+
+type HealthConfig struct {
+	Frequency       time.Duration `toml:"frequency"`
+	Timeout         time.Duration `toml:"timeout"`
+	AllowedFailures int           `toml:"allowedFailures"`
 }
 
 type TLSConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -423,6 +423,18 @@ func setDefaultConfig(cfg *config.Config) {
 		cfg.GRPC.Address = []string{appdefaults.Address}
 	}
 
+	if cfg.Health.Frequency == 0 {
+		cfg.Health.Frequency = appdefaults.HealthFrequency
+	}
+
+	if cfg.Health.Timeout == 0 {
+		cfg.Health.Timeout = appdefaults.HealthTimeout
+	}
+
+	if cfg.Health.AllowedFailures == 0 {
+		cfg.Health.AllowedFailures = appdefaults.HealthAllowedFailures
+	}
+
 	if cfg.Workers.OCI.Platforms == nil {
 		cfg.Workers.OCI.Platforms = formatPlatforms(archutil.SupportedPlatforms(false))
 	}
@@ -633,7 +645,11 @@ func serverCredentials(cfg config.TLSConfig) (*tls.Config, error) {
 }
 
 func newController(c *cli.Context, cfg *config.Config) (*control.Controller, error) {
-	sessionManager, err := session.NewManager()
+	sessionManager, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       cfg.Health.Frequency,
+		HealthAllowedFailures: cfg.Health.AllowedFailures,
+		HealthTimeout:         cfg.Health.Timeout,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
@@ -47,7 +48,11 @@ func TestContentAttachable(t *testing.T) {
 	s, err := session.NewSession(ctx, "foo", "bar")
 	require.NoError(t, err)
 
-	m, err := session.NewManager()
+	m, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 
 	a := NewAttachable(attachableStores)

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/testutil"
@@ -31,7 +32,11 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	s, err := session.NewSession(ctx, "foo", "bar")
 	require.NoError(t, err)
 
-	m, err := session.NewManager()
+	m, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 
 	fs := NewFSSyncProvider([]SyncedDir{{Name: "test0", Dir: tmpDir}})

--- a/util/appdefaults/appdefaults_all.go
+++ b/util/appdefaults/appdefaults_all.go
@@ -1,0 +1,9 @@
+package appdefaults
+
+import "time"
+
+const (
+	HealthAllowedFailures = 1
+	HealthFrequency       = 1 * time.Second
+	HealthTimeout         = 10 * time.Second
+)

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -68,7 +68,11 @@ func TestRuncWorker(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := tests.NewCtx("buildkit-test")
-	sm, err := session.NewManager()
+	sm, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 	snap := tests.NewBusyboxSourceSnapshot(ctx, t, w, sm)
 
@@ -190,7 +194,11 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := tests.NewCtx("buildkit-test")
-	sm, err := session.NewManager()
+	sm, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 	snap := tests.NewBusyboxSourceSnapshot(ctx, t, w, sm)
 	root, err := w.CacheMgr.New(ctx, snap, nil)

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -39,7 +39,11 @@ func NewCtx(s string) context.Context {
 func TestWorkerExec(t *testing.T, w *base.Worker) {
 	ctx := NewCtx("buildkit-test")
 	ctx, cancel := context.WithCancel(ctx)
-	sm, err := session.NewManager()
+	sm, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 
 	snap := NewBusyboxSourceSnapshot(ctx, t, w, sm)
@@ -162,7 +166,11 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 
 func TestWorkerExecFailures(t *testing.T, w *base.Worker) {
 	ctx := NewCtx("buildkit-test")
-	sm, err := session.NewManager()
+	sm, err := session.NewManager(&session.ManagerOpt{
+		HealthFrequency:       1 * time.Second,
+		HealthTimeout:         10 * time.Second,
+		HealthAllowedFailures: 1,
+	})
 	require.NoError(t, err)
 
 	snap := NewBusyboxSourceSnapshot(ctx, t, w, sm)


### PR DESCRIPTION
This is what I am working on upstreaming. Perhaps test this here while I work on that, as Vlad suggested?

Sample TOML config:

```
[health]
  frequency = "10s"
  timeout = "1m"
  allowedFailures = 3
```

Its totally an optional section, and each has a default value that matches what it _used_ to do.