### PR TITLE
Use WithStack instead of Wrap on Reserve client

### DIFF
--- a/client/reserve.go
+++ b/client/reserve.go
@@ -10,7 +10,7 @@ import (
 func (c *Client) Reserve(ctx context.Context) error {
 	_, err := c.controlClient().Reserve(ctx, &controlapi.ReserveRequest{})
 	if err != nil {
-		return errors.Wrap(err, "failed to call reserve")
+		return errors.WithStack(err)
 	}
 	return nil
 }


### PR DESCRIPTION
Using `pkg/errors` here doesn't play nice for applications that haven't adopted that library. 

For example, in cloud, I was unable to check for a gRPC error code using their standard `status` package. I had to parse the string like this:

```golang
strings.Contains(err.Error(), "Unimplemented"):
```

This change shouldn't affect how code works in earthly-core (in fact I'm removing the call to Reserve in earthly-core anyways) ... and it will allow us to parse the error more easily in earthly-cloud. 

Follow-up thought - it's not very agnostic of buildkit to be hiding the standard gRPC codes inside 3rd-party pkg/errors in the first place, but I realize it's already like that in the main fork. 