### PR TITLE
Add ability to use OCI hooks from config for runc workers

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -95,7 +95,7 @@ type OCIConfig struct {
 	// MaxParallelism is the maximum number of parallel build steps that can be run at the same time.
 	MaxParallelism int `toml:"max-parallelism"`
 
-	// Hooks are things you can run during any phase of the OCI container runtime lifecycle.
+	// earthly-specific: Hooks are things you can run during any phase of the OCI container runtime lifecycle.
 	Hooks []Hook `toml:"hook"`
 }
 

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -94,6 +94,9 @@ type OCIConfig struct {
 
 	// MaxParallelism is the maximum number of parallel build steps that can be run at the same time.
 	MaxParallelism int `toml:"max-parallelism"`
+
+	// Hooks are things you can run during any phase of the OCI container runtime lifecycle.
+	Hooks []Hook `toml:"hook"`
 }
 
 type ContainerdConfig struct {
@@ -126,4 +129,12 @@ type DNSConfig struct {
 	Nameservers   []string `toml:"nameservers"`
 	Options       []string `toml:"options"`
 	SearchDomains []string `toml:"searchDomains"`
+}
+
+type Hook struct {
+	Phase   string
+	Path    string
+	Args    []string
+	Env     []string
+	Timeout *int
 }

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -299,7 +299,18 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		parallelismSem = semutil.NewWeighted(int64(cfg.MaxParallelism))
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
+	ociHooks := []oci.OciHook{}
+	for _, h := range cfg.Hooks {
+		ociHooks = append(ociHooks, oci.OciHook{
+			Phase:   h.Phase,
+			Path:    h.Path,
+			Args:    h.Args,
+			Env:     h.Env,
+			Timeout: h.Timeout,
+		})
+	}
+
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent, ociHooks)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/oci/hooks.go
+++ b/executor/oci/hooks.go
@@ -1,0 +1,53 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type OciHook struct {
+	Phase   string
+	Path    string
+	Args    []string
+	Env     []string
+	Timeout *int
+}
+
+func WithHook(hook OciHook) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *oci.Spec) error {
+		if s.Hooks == nil {
+			s.Hooks = &specs.Hooks{}
+		}
+
+		h := specs.Hook{
+			Path:    hook.Path,
+			Args:    hook.Args,
+			Env:     hook.Args,
+			Timeout: hook.Timeout,
+		}
+
+		// Yes, its verbose... but it reads _so much better_ than the golang reflection version
+		switch hook.Phase {
+		case "prestart":
+			s.Hooks.Prestart = append(s.Hooks.Prestart, h)
+		case "createRuntime":
+			s.Hooks.CreateRuntime = append(s.Hooks.CreateRuntime, h)
+		case "createContainer":
+			s.Hooks.CreateContainer = append(s.Hooks.CreateContainer, h)
+		case "startContainer":
+			s.Hooks.StartContainer = append(s.Hooks.StartContainer, h)
+		case "poststart":
+			s.Hooks.Poststart = append(s.Hooks.Poststart, h)
+		case "poststop":
+			s.Hooks.Poststop = append(s.Hooks.Poststop, h)
+		default:
+			return fmt.Errorf("%s is not a valid lifecycle hook", hook.Phase)
+		}
+
+		return nil
+	}
+}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -34,7 +34,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, parallelismSem *semutil.Weighted, traceSocket, defaultCgroupParent string) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, parallelismSem *semutil.Weighted, traceSocket, defaultCgroupParent string, hooks []oci.OciHook) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -67,6 +67,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		ApparmorProfile:     apparmorProfile,
 		TracingSocket:       traceSocket,
 		DefaultCgroupParent: defaultCgroupParent,
+		Hooks:               hooks,
 	}, np)
 	if err != nil {
 		return opt, err

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -67,7 +67,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		ApparmorProfile:     apparmorProfile,
 		TracingSocket:       traceSocket,
 		DefaultCgroupParent: defaultCgroupParent,
-		Hooks:               hooks,
+		Hooks:               hooks, //earthly-specific
 	}, np)
 	if err != nil {
 		return opt, err

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -38,7 +38,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) base.WorkerOpt {
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil, "", "")
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil, "", "", []oci.OciHook{})
 	require.NoError(t, err)
 
 	return workerOpt


### PR DESCRIPTION
Relies on https://github.com/earthly/earthly/pull/2289 to be present in the image.