### PR TITLE
Don't use a timeout for pullping

### DIFF
--- a/exporter/earthlyoutputs/export.go
+++ b/exporter/earthlyoutputs/export.go
@@ -538,16 +538,12 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 			}
 		}
 		pullPingChan = pullping.PullPingChannel(ctx, pullImgs, resp, caller)
-		ctxTimeout, cancel := context.WithTimeout(ctx, 1*time.Hour)
-		defer cancel()
 		// wait for the client to finish pulling
 		select {
 		case err := <-pullPingChan:
 			if err != nil {
 				return nil, errors.Wrap(err, "pull ping error")
 			}
-		case <-ctxTimeout.Done():
-			return nil, errors.Wrap(ctxTimeout.Err(), "pull ping ctx done")
 		case <-caller.Context().Done():
 			return nil, errors.Wrap(caller.Context().Err(), "caller context done")
 		}


### PR DESCRIPTION
Some images could be really big and there's no reason why we should interrupt the output for them.