### PR TITLE
support rosetta emulator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0
+	github.com/moby/sys/mount v0.3.3
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/moby/sys/signal v0.7.0
 	github.com/morikuni/aec v1.0.0
@@ -137,7 +138,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/moby/sys/mount v0.3.3 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/term v0.0.0-20221120202655-abb19827d345 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect


### PR DESCRIPTION
This PR adds support for using [ROSETTA](https://en.wikipedia.org/wiki/Rosetta_(software)) emulator with buildkit.

Background:
Docker Desktop for Mac supports using `ROSETTA` instead of `QEMU` emulator.
After some investigation, it appears buildkit also supports rosetta except for a minor problem:
When buildkit checks for supported platforms, it attempts to run a few test executables according to which the platforms will be reported back.

It appears that for amd64 the applicable executable failed to run with `ROSETTA` (and succeeded with `QEMU`).
It turns out the executable is run with [chroot](https://en.wikipedia.org/wiki/Chroot) (which runs in an isolated environment), and that ROSETTA requires access /proc/self/exe which is not accessible when using `chroot` by default.
So, in order to address the issue, the fix here is to temporarily mount the virtual fs `proc` before the executable is run.

The following Earthfile exemplifies the issue:
```earthly
VERSION 0.7

PROJECT org/project

FROM --platform=linux/amd64 alpine

image:
    WORKDIR /app
    COPY github.com/earthly/earthly/examples/multiplatform-cross-compile+build/main tester
    WORKDIR /
    COPY entrypoint.sh .
    ENTRYPOINT ["sh", "entrypoint.sh"]
    SAVE IMAGE emulator-tester

run:
    LOCALLY
    WAIT
        BUILD +image
    END
    ARG MOUNT="false"
    RUN docker run --privileged --platform=linux/amd64 --rm emulator-tester $MOUNT
```

Also create `entrypoint.sh` where `Earthfile` is located:
```sh
#!/bin/sh
set -e

MOUNT_PROC=$1
EMULATOR=$(ps -o pid,user,args |egrep -e "^\s*1 root")

IS_ROSETTA=false
if echo $EMULATOR | grep -q qemu; then
    echo "using qemu"
elif echo $EMULATOR | grep -q rosetta; then
    echo "using rosetta"
    IS_ROSETTA=true
fi

if $IS_ROSETTA; then
    NEW_ROOT="/tmp/newroot"
    MOUNT_PATH="$NEW_ROOT/proc"
    mkdir -p $MOUNT_PATH
    cp /app/tester $NEW_ROOT/.

    if "$MOUNT_PROC" = "true" ; then
        mount -t proc none $MOUNT_PATH
    fi
    chroot $NEW_ROOT /tester
    if "$MOUNT_PROC" = "true" ; then
        umount $MOUNT_PATH
    fi
fi

```
Execute `earthly +run` to run a test image with linux/amd64 platform.
The test would print out the emulator used and a "hello world" message in case it succeeds.

If `ROSETTA` is the active emulator, the target will fail by default because the `proc` filesystem is not mounted.

However, if you run `earthly +run --MOUNT=true` the target should succeed.