### PR TITLE
fix: nil pointer bug

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -341,7 +341,10 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 			}
 		} else if errors.Is(err, context.Canceled) {
 			// earthly-specific prevent context canceled errors from being permanent
-			r.expires = time.Now()
+			r = &authResult{
+				expires: time.Now().Add(-time.Hour),
+			}
+			err = nil
 		}
 	}()
 


### PR DESCRIPTION
We must create a new response struct before creating an expired token.